### PR TITLE
Add new endpoint to run singular health checks

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,8 @@
 # Health checks
 Health checks can be found under the `__health` endpoint. Each health check tests a part of the site continually, and in doing so indicates the overall health of the site.
 
+Singular health checks can be run by using their id found at `/__health/{HealthCheckId}`.
+
 Health checks in this package conform to the FT Health Check Standard.
 
 ## Installation

--- a/src/HealthCheckBundle/Controller/HealthCheckController.php
+++ b/src/HealthCheckBundle/Controller/HealthCheckController.php
@@ -2,21 +2,24 @@
 
 namespace FT\HealthCheckBundle\Controller;
 
-use FT\HealthCheckBundle\Factory\HealthCheckResponseFactory;
-use FT\HealthCheckBundle\HealthCheck\HealthCheck;
-use FT\HealthCheckBundle\HealthCheck\HealthCheckHandlerInterface;
-use FT\HealthCheckBundle\Service\CachedHealthCheckService;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Exception;
+use FT\HealthCheckBundle\HealthCheck\HealthCheck;
+use FT\HealthCheckBundle\HealthCheck\HealthCheckRegistry;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use FT\HealthCheckBundle\Service\CachedHealthCheckService;
+use FT\HealthCheckBundle\Factory\HealthCheckResponseFactory;
+use FT\HealthCheckBundle\Service\HealthCheckExecutorService;
+use FT\HealthCheckBundle\HealthCheck\HealthCheckHandlerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class HealthCheckController extends Controller
 {
     /**
      * Stores all the handles that should be executed when the {@see self::healthCheckAction} method is called
      *
-     * @var HealthCheckHandlerInterface[]
+     * @var HealthCheckRegistry
      */
-    protected $healthCheckHandles;
+    protected $healthCheckRegistry;
 
     /**
      * @var HealthCheckResponseFactory
@@ -24,28 +27,20 @@ class HealthCheckController extends Controller
     protected $healthCheckResponseFactory;
 
     /**
-     * @var CachedHealthCheckService
+     * The health check executor service
+     *
+     * @var HealthCheckExecutorService
      */
-    protected $cachedHealthCheckService;
+    protected $healthCheckExecutorService;
 
     public function __construct(
         HealthCheckResponseFactory $healthCheckResponseFactory,
-        CachedHealthCheckService $cachedHealthCheckService
+        HealthCheckRegistry $healthCheckRegistry,
+        HealthCheckExecutorService $healthCheckExecutorService
     ) {
         $this->healthCheckResponseFactory = $healthCheckResponseFactory;
-        $this->cachedHealthCheckService = $cachedHealthCheckService;
-        $this->healthCheckHandles = [];
-    }
-
-    /**
-     * Used to register a health check handle that should be executed when {@see self::healthCheckAction} is called.
-     *
-     * @param HealthCheckHandlerInterface $healthCheck
-     * @return void
-     */
-    public function addHealthCheck(HealthCheckHandlerInterface $healthCheck)
-    {
-        $this->healthCheckHandles[] = $healthCheck;
+        $this->healthCheckRegistry = $healthCheckRegistry;
+        $this->healthCheckExecutorService = $healthCheckExecutorService;
     }
 
     /**
@@ -53,23 +48,36 @@ class HealthCheckController extends Controller
      */
     public function healthCheckAction()
     {
-        $healthChecks = array_map(function ($healthCheckHandle) {
-            try{
-                $healthCheck = $this->cachedHealthCheckService->runHealthCheckHandle($healthCheckHandle);
-            } catch (Exception $e) {
-                $healthCheck = new HealthCheck();
-                $healthCheck = $healthCheck
-                    ->withId($healthCheckHandle->getHealthCheckId())
-                    ->withName($healthCheckHandle->getHealthCheckId())
-                    ->withSeverity(3)
-                    ->withOk(false)
-                    ->withBusinessImpact("A healthcheck failed to run. It is unknown what effects this would have for users or the editorial team.")
-                    ->withPanicGuide("Read the output of the check to find where the fatal error was thrown. Note that this healthcheck failing might be a symptom of a larger problem and more serious health check failures should be looked into first.")
-                    ->withTechnicalSummary("This is a placeholder for the ". get_class($healthCheckHandle) ." heath check that failed to run successfully.")
-                    ->withCheckOutputException($e);
-            }
-            return $healthCheck;
-        }, $this->healthCheckHandles);
-        return $this->healthCheckResponseFactory->getHealthCheckResponse($healthChecks);
+        return $this->healthCheckResponseFactory->getHealthCheckResponse(
+            $this->healthCheckExecutorService->runAll(
+                $this->healthCheckRegistry->getAllHealthChecks()
+            )
+        );
+    }
+
+    /**
+     * Execute Health check by id
+     * @param string $healthCheckId
+     */
+    public function healthCheckByIdAction($healthCheckId)
+    {
+        $healthCheckHandler = $this->healthCheckRegistry->getHealthCheckById($healthCheckId);
+
+        //Fail id we cannot find the healthcheck
+        if(is_null($healthCheckHandler)){
+            return new JsonResponse(
+                [
+                    'code' => 404,
+                    'message' => 'No health check registered with that id'
+                ],
+                404
+            );
+        }
+
+        return $this->healthCheckResponseFactory->getHealthCheckResponse(
+            [$this->healthCheckExecutorService->run(
+                $healthCheckHandler
+            )]
+        );
     }
 }

--- a/src/HealthCheckBundle/DependencyInjection/HealthCheckPass.php
+++ b/src/HealthCheckBundle/DependencyInjection/HealthCheckPass.php
@@ -13,10 +13,11 @@ class HealthCheckPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('health_check.controller')) {
+        if (!$container->hasDefinition('health_check.registry')) {
             return;
         }
-        $healthCheckController = $container->getDefinition('health_check.controller');
+
+        $healthCheckRegister = $container->getDefinition('health_check.registry');
 
         // Get health checks.
         $healthChecks = $container->findTaggedServiceIds('health_check');
@@ -72,8 +73,10 @@ class HealthCheckPass implements CompilerPassInterface
         }
 
         $converterIdsByPriority = $this->sortConverterIds($converterIdsByPriority);
+
+        //Register new health checks
         foreach ($converterIdsByPriority as $referenceId) {
-            $healthCheckController->addMethodCall('addHealthCheck', array(new Reference($referenceId)));
+            $healthCheckRegister->addMethodCall('registerHealthCheck', array(new Reference($referenceId)));
         }
     }
     

--- a/src/HealthCheckBundle/EventListener/HealthCheckListener.php
+++ b/src/HealthCheckBundle/EventListener/HealthCheckListener.php
@@ -33,11 +33,19 @@ class HealthCheckListener{
         $request = $event->getRequest();
 
         //Do nothing when we are not specifically looking for the health check
-        if($request->getPathInfo() !== self::HEALTH_CHECK_ROUTE){
+        if(substr($request->getPathInfo(), 0 , strlen(self::HEALTH_CHECK_ROUTE)) !== self::HEALTH_CHECK_ROUTE){
             return;
         }
+
+        //Try to get the health check id if we are using (+ 1 to ignore the trailing slash /__health/)
+        $healthCheckId = substr($request->getPathInfo(), strlen(self::HEALTH_CHECK_ROUTE) + 1);
         
-        //Force health check to run and immidently return
-        $event->setResponse($this->healthCheckController->healthCheckAction());
+        if($healthCheckId === false || $healthCheckId === ""){
+            //Force health check to run and immediately return
+            $event->setResponse($this->healthCheckController->healthCheckAction());
+        } else {
+            // Get by id if an id is given
+            $event->setResponse($this->healthCheckController->healthCheckByIdAction($healthCheckId));
+        }
     }
 }

--- a/src/HealthCheckBundle/HealthCheck/HealthCheckRegistry.php
+++ b/src/HealthCheckBundle/HealthCheck/HealthCheckRegistry.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace FT\HealthCheckBundle\HealthCheck;
+
+use DomainException;
+use FT\HealthCheckBundle\HealthCheck\HealthCheckHandlerInterface;
+
+/**
+ * Used to store the various health checks used across the application
+ */
+class HealthCheckRegistry {
+    /**
+     * Contains an array of health checks ordered by priority from highest to lowest 
+     *
+     * @var HealthCheckHandlerInterface[]
+     */
+    protected $registeredHealthChecks;
+
+    /**
+     * Contains a mapping between health check Id's and their given run order. 
+     * Used as a lookup table when retrieving health checks by id .
+     * Given in the form ['Health Check Id' => {int}]
+     *
+     * @var int[]
+     */
+    protected $healthCheckIdToRunOrderMap;
+
+    public function __construct() {
+        $this->registeredHealthChecks = [];
+        $this->healthCheckIdToRunOrderMap = [];
+    }
+
+    /**
+     * Registers a health check with this service 
+     *
+     * @throws DomainException (If the health check given has a non unique id)
+     * @param HealthCheckHandlerInterface $healthCheck
+     * @return void
+     */
+    public function registerHealthCheck(HealthCheckHandlerInterface $healthCheck):void{
+        $healthCheckId = $healthCheck->getHealthCheckId();
+
+        if(array_key_exists($healthCheckId, $this->healthCheckIdToRunOrderMap)){
+            //Add protection against unique key violation
+            throw new DomainException("Registered health checks must give valid unique ID. Id '$healthCheckId' given by instance of ".
+                 get_class($healthCheck) . ' already in use by instance of ' . get_class($this->getHealthCheckById($healthCheckId)) . '.');
+        }
+
+        //We keep the health checks in order (not indexing by key) given the are registered given in a specific order
+        $this->registeredHealthChecks[] = $healthCheck;
+
+        //Index the health check using an in memory look up table so we can quickly query by healthcheck Id 
+        $this->healthCheckIdToRunOrderMap[$healthCheck->getHealthCheckId()] = count($this->registeredHealthChecks) -1;
+    }
+
+    /**
+     * Gets all the registered health checks in the order they need to be run 
+     *
+     * @return HealthCheckHandlerInterface[]
+     */
+    public function getAllHealthChecks(): array{
+        return $this->registeredHealthChecks;
+    }
+
+    /**
+     * Gets health check from registry by id
+     *
+     * @param string $healthCheckId
+     * @return HealthCheckHandlerInterface|null
+     */
+    public function getHealthCheckById(string $healthCheckId) : ?HealthCheckHandlerInterface {
+
+        if(!array_key_exists($healthCheckId, $this->healthCheckIdToRunOrderMap)){
+            return null;
+        }
+
+        return $this->registeredHealthChecks[
+            $this->healthCheckIdToRunOrderMap[$healthCheckId]
+        ];  
+    }
+}

--- a/src/HealthCheckBundle/Resources/config/routing.yml
+++ b/src/HealthCheckBundle/Resources/config/routing.yml
@@ -3,3 +3,8 @@ healthCheck:
     path: /__health
     defaults:
         _controller: health_check.controller:healthCheckAction
+
+healthCheckId:
+    path: /__health/{healthCheckId}
+    defaults:
+        _controller: health_check.controller:healthCheckByIdAction

--- a/src/HealthCheckBundle/Resources/config/services.yml
+++ b/src/HealthCheckBundle/Resources/config/services.yml
@@ -3,7 +3,8 @@ services:
         class: FT\HealthCheckBundle\Controller\HealthCheckController
         arguments:
             - '@health_check.factory'
-            - '@health_check.service.cache'
+            - '@health_check.registry'
+            - '@health_check.service.executor'
 
     health_check.factory:
         class: FT\HealthCheckBundle\Factory\HealthCheckResponseFactory
@@ -20,3 +21,11 @@ services:
             - '@service_container'
         calls:
             - [setCachePoolFromServiceId, ["@=container.hasParameter('health_check.cache_pool') ? parameter('health_check.cache_pool') : ''"]]
+    
+    health_check.service.executor:
+        class: FT\HealthCheckBundle\Service\HealthCheckExecutorService
+        arguments:
+            - '@health_check.service.cache'
+
+    health_check.registry:
+        class: FT\HealthCheckBundle\HealthCheck\HealthCheckRegistry

--- a/src/HealthCheckBundle/Service/CachedHealthCheckService.php
+++ b/src/HealthCheckBundle/Service/CachedHealthCheckService.php
@@ -92,7 +92,7 @@ class CachedHealthCheckService
                 //In the event we only run it every so often
                 if ($healthCheck->passed()) {
                     $cacheItem->set($healthCheck);
-                    $cacheItem->expiresAfter($healthCheckHandle->getHealthCheckInterval());
+                    $cacheItem->expiresAfter(time() + $healthCheckHandle->getHealthCheckInterval());
                     $cacheItem->save();
                 }
             } else {

--- a/src/HealthCheckBundle/Service/HealthCheckExecutorService.php
+++ b/src/HealthCheckBundle/Service/HealthCheckExecutorService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FT\HealthCheckBundle\Service;
+
+use FT\HealthCheckBundle\HealthCheck\HealthCheck;
+use FT\HealthCheckBundle\Service\CachedHealthCheckService;
+use FT\HealthCheckBundle\HealthCheck\HealthCheckHandlerInterface;
+
+/**
+ * Service used to run given health checks
+ */
+class HealthCheckExecutorService
+{
+
+    /**
+     * @var CachedHealthCheckService
+     */
+    protected $cachedHealthCheckService;
+
+    /**
+     * @param CachedHealthCheckService $cachedHealthCheckService
+     */
+    public function __construct(CachedHealthCheckService $cachedHealthCheckService)
+    {
+        $this->cachedHealthCheckService = $cachedHealthCheckService;
+    }
+
+    /**
+     * Will execute a single health check handle and return it's respective health check
+     *
+     * @param HealthCheckHandlerInterface $healthCheckHandle
+     * @return HealthCheck
+     */
+    public function run(HealthCheckHandlerInterface $healthCheckHandle) : HealthCheck
+    {
+        try {
+            return $this->cachedHealthCheckService->runHealthCheckHandle($healthCheckHandle);
+        } catch (Exception $e) {
+            $healthCheck = new HealthCheck();
+            $healthCheck = $healthCheck
+                ->withId($healthCheckHandle->getHealthCheckId())
+                ->withName($healthCheckHandle->getHealthCheckId())
+                ->withSeverity(3)
+                ->withOk(false)
+                ->withBusinessImpact("A healthcheck failed to run. It is unknown what effects this would have for users or the editorial team.")
+                ->withPanicGuide("Read the output of the check to find where the fatal error was thrown. Note that this healthcheck failing might be a symptom of a larger problem and more serious health check failures should be looked into first.")
+                ->withTechnicalSummary("This is a placeholder for the ". get_class($healthCheckHandle) ." heath check that failed to run successfully.")
+                ->withCheckOutputException($e);
+            return $healthCheck;
+        }
+    }
+
+    /**
+     * Will run all the given health check handles and return an array of health checks in the order they were given
+     *
+     * @param HealthCheckHandlerInterface[] $healthCheckHandles
+     * @return HealthCheck[]
+     */
+    public function runAll(array $healthCheckHandles) : array
+    {
+        return array_map([$this, 'run'], $healthCheckHandles);
+    }
+}


### PR DESCRIPTION
This refactor adds a new endpoint to run / get the status of / singular health checks