### PR TITLE
SUP-395/CircleCI Dockerhub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,12 @@ workflows:
   version: 2
   run-unit-tests:
     jobs:
-      - run-tests-71
-      - run-tests-72
-      - run-tests-73
-      - run-tests-74
+      - run-tests-71:
+          context: dockerhub-shared
+      - run-tests-72:
+          context: dockerhub-shared
+      - run-tests-73:
+          context: dockerhub-shared
+      - run-tests-74:
+          context: dockerhub-shared
     


### PR DESCRIPTION
What:
Authenticate pipeline with DockerHub
Why: 
On 1st November dockerhub will be imposing rate-limits on all unauthenticated requests
https://gist.github.com/wheresrhys/4a55585f73fca74edf423addf4825d3d