### PR TITLE
#20 composer v1 for ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer --1
             php -r "unlink('composer-setup.php');"
       - restore_cache:
           keys:
@@ -37,7 +37,7 @@ jobs:
           command: |
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer --1
             php -r "unlink('composer-setup.php');"
       - restore_cache:
           keys:
@@ -71,7 +71,7 @@ jobs:
             - composer-cache-7.3-{{ checksum "composer.json" }}
       - run:
           name: Run composer install
-          command: composer install --no-scripts --no-progress --no-interaction
+          command: composer install --no-scripts --no-progress --no-interaction --1
       - save_cache:
           key: composer-cache-7.3-{{ checksum "composer.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,14 @@ jobs:
           command: |
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer --1
             php -r "unlink('composer-setup.php');"
       - restore_cache:
           keys:
             - composer-cache-7.3-{{ checksum "composer.json" }}
       - run:
           name: Run composer install
-          command: composer install --no-scripts --no-progress --no-interaction --1
+          command: composer install --no-scripts --no-progress --no-interaction 
       - save_cache:
           key: composer-cache-7.3-{{ checksum "composer.json" }}
           paths:


### PR DESCRIPTION
As given in https://github.com/Financial-Times/php-health-check/issues/20
Ci builds are currently failing in production. This branch aims to fix that by virtue of locking composer versions for 73 72 and 71 to composer v1