### PR TITLE
fix: Ordering based on priority

### DIFF
--- a/src/HealthCheckBundle/DependencyInjection/HealthCheckPass.php
+++ b/src/HealthCheckBundle/DependencyInjection/HealthCheckPass.php
@@ -88,7 +88,17 @@ class HealthCheckPass implements CompilerPassInterface
      */
     protected function sortConverterIds(array $converterIdsByPriority)
     {
-        asort($converterIdsByPriority);
-        return call_user_func_array('array_merge', $converterIdsByPriority);
+        // Sort by priority
+        ksort($converterIdsByPriority);
+        $converterIdsByPriority = array_reverse($converterIdsByPriority, true);
+
+        //Sort by value if same priority
+        $converterIdsByPriority = array_map(function($array){
+            asort($array);
+            return $array;
+        }, $converterIdsByPriority);
+
+        //Merge down to single array
+        return array_merge(...$converterIdsByPriority);
     }
 }


### PR DESCRIPTION
Priority is not been taken into account when calculating the order calls to `registerHealthCheck` are been run. This PR fixes that behaviour